### PR TITLE
Suggested way to add memory to chain using Faiss

### DIFF
--- a/app/chat_handler.py
+++ b/app/chat_handler.py
@@ -26,7 +26,7 @@ async def process_chat_message(text: str, chat_id: int) -> Union[str, Tuple[str,
     # Process the message based on the topic
     output = ""
     if topic == "chat":
-        output = process_chat(text, history_string)
+        output = process_chat(chat_id, text, history_string)
     elif topic == "image":
         output = await process_image(text, history_string)
     elif topic == "calendar":

--- a/app/config.py
+++ b/app/config.py
@@ -36,3 +36,6 @@ BOT_NAME = 'Lago'
 
 # Use BabyAGI or not?
 BABYAGI = False
+
+# Where to store conversation memories etc.
+HISTORY_DIR = './history'

--- a/app/config.py
+++ b/app/config.py
@@ -39,3 +39,6 @@ BABYAGI = False
 
 # Where to store conversation memories etc.
 HISTORY_DIR = './history'
+
+# TODO Numbers For testing purposes only, should be changed later
+MEMORYCONFIG = {'K_contextual':2, 'K_latest':4} 

--- a/app/templates.py
+++ b/app/templates.py
@@ -30,7 +30,14 @@ def get_template(template_type: str) -> str:
         {BOT_NAME} is designed to be able to assist with a wide range of tasks, from answering simple questions to providing in-depth explanations and discussions on a wide range of topics. As a language model, {BOT_NAME} is able to generate human-like text based on the input it receives, allowing it to engage in natural-sounding conversations and provide responses that are coherent and relevant to the topic at hand.
         {BOT_NAME} is constantly learning and improving, and its capabilities are constantly evolving. It is able to process and understand large amounts of text, and can use this knowledge to provide accurate and informative responses to a wide range of questions. Additionally, {BOT_NAME} is able to generate its own text based on the input it receives, allowing it to engage in discussions and provide explanations and descriptions on a wide range of topics.
         Overall, {BOT_NAME} is a powerful tool that can help with a wide range of tasks and provide valuable insights and information on a wide range of topics. Whether you need help with a specific question or just want to have a conversation about a particular topic, {BOT_NAME} is here to assist.
+        History of relevant conversation to the current topic:
+
         {{history}}
+
+        Recent conversaton: 
+
+        {{recent_history}}
+        
         Human: {{human_input}}
         {BOT_NAME} AI response:
         """

--- a/app/utils.py
+++ b/app/utils.py
@@ -57,17 +57,17 @@ def load_memory(chat_id: str):
         pass
 
     # Create new memory
-
+    memconfig = config.MEMORYCONFIG
     embedding_size = 1536 # Dimensions of the OpenAIEmbeddings
     index = faiss.IndexFlatL2(embedding_size)
     embedding_fn = OpenAIEmbeddings(openai_api_key=config.OPENAI_API_KEY).embed_query
     vectorstore = FAISS(embedding_fn, index, InMemoryDocstore({}), {})
-    retriever = vectorstore.as_retriever(search_kwargs=dict(k=2))
+    retriever = vectorstore.as_retriever(search_kwargs=dict(k=memconfig["K_latest"]))
 
     conv_memory = ConversationBufferWindowMemory(
         memory_key="recent_history",
         input_key="human_input",
-        k=4, # Number of latest interactions to keep in memory
+        k=memconfig["K_latest"], # Number of latest interactions to keep in memory
     )
 
     faissmemory = VectorStoreRetrieverMemory(retriever=retriever)

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,13 +1,23 @@
+import os
+import faiss
+import pickle
+import config
 import openai
+import functools
 from langchain import OpenAI, LLMChain, PromptTemplate
-from langchain.chains.conversation.memory import ConversationBufferMemory
+from langchain.chains.conversation.memory import ConversationBufferWindowMemory, ConversationBufferMemory
+from langchain.agents.agent_toolkits import ZapierToolkit
+from langchain.utilities.zapier import ZapierNLAWrapper
+from langchain.agents import initialize_agent
+from langchain.docstore import InMemoryDocstore
+from langchain.vectorstores import FAISS
+from langchain.embeddings import OpenAIEmbeddings
+from langchain.memory import VectorStoreRetrieverMemory, CombinedMemory
 from langchain.chat_models import ChatOpenAI
 from config import SELECTED_MODEL, IMAGE_SIZE, ZAPIER_NLA_API_KEY, BOT_NAME
 from models import initialize_language_model
 from templates import get_template
-from langchain.agents.agent_toolkits import ZapierToolkit
-from langchain.utilities.zapier import ZapierNLAWrapper
-from langchain.agents import initialize_agent
+
 
 
 if ZAPIER_NLA_API_KEY:
@@ -19,6 +29,87 @@ else:
     zapier = None
     toolkit = None
     agent = None
+
+
+def load_memory(chat_id: str):
+    '''Loads memory for langchain chain 
+    It is a combination of two types of memory - first: Faiss based memory and 
+    second: recent K interaction memory. Faiss baised memory retrieves top P related
+    memory to the curent input. This has the benefit of being able to retrieve contextual
+    memory that is burried deep in the conversation history, but also being highly 
+    relevant to the latest interactions.
+
+    Args:
+        chat_id (str): Chat id (used for caching)
+
+    Returns:
+        memory object for langchain chain
+    '''
+
+    # First check if memory is saved on disk and load it
+
+    fp = os.path.join(config.HISTORY_DIR, '{}_memory.p'.format(chat_id))
+    try:
+        with open(fp, 'rb') as f:
+            memory = pickle.load(f)
+            return memory
+    except FileNotFoundError:
+        pass
+
+    # Create new memory
+
+    embedding_size = 1536 # Dimensions of the OpenAIEmbeddings
+    index = faiss.IndexFlatL2(embedding_size)
+    embedding_fn = OpenAIEmbeddings(openai_api_key=config.OPENAI_API_KEY).embed_query
+    vectorstore = FAISS(embedding_fn, index, InMemoryDocstore({}), {})
+    retriever = vectorstore.as_retriever(search_kwargs=dict(k=2))
+
+    conv_memory = ConversationBufferWindowMemory(
+        memory_key="recent_history",
+        input_key="human_input",
+        k=4, # Number of latest interactions to keep in memory
+    )
+
+    faissmemory = VectorStoreRetrieverMemory(retriever=retriever)
+
+    memory = CombinedMemory(memories=[faissmemory, conv_memory])
+    return memory
+
+
+@functools.cache
+def load_chat_model(chat_id: str):
+    ''' Loads the langchain chain for chat.
+        cache is used to avoid reloading the model for each request
+
+    Args:
+        chat_id (str): Chat id (used for caching)
+
+    Returns:
+        langchain chain for chat
+    '''
+    print ('Loading chat model...')
+    prompt_template = get_template("chat")
+    prompt = PromptTemplate(input_variables=["history", "recent_history", "human_input"], template=prompt_template)
+    memory = load_memory(chat_id)
+    return LLMChain(
+        llm=initialize_language_model(SELECTED_MODEL),
+        prompt=prompt,
+        verbose=True,
+        memory=memory
+    )
+
+
+def save_memory_to_disk(chat_id, chatgpt_chain):
+    ''' Saves the memory of the langchain chain to disk '''
+    # TODO memory is currently serialized and saved at every step
+    # It's probably better to do it on exit or on every 10 steps etc.
+    
+    if not os.path.exists(config.HISTORY_DIR):
+        os.makedirs(config.HISTORY_DIR)
+    fp = os.path.join(config.HISTORY_DIR, '{}_memory.p'.format(chat_id))
+    with open(fp, 'wb') as f:
+        pickle.dump(chatgpt_chain.memory, f, protocol=pickle.HIGHEST_PROTOCOL)
+
 
 async def get_topic(text: str, history_string: str) -> str:
     """
@@ -40,34 +131,26 @@ async def get_topic(text: str, history_string: str) -> str:
         verbose=False,
         memory=ConversationBufferMemory(),
     )
-
     topic = chatgpt_chain.predict(history=history_string, human_input=text)
 
     return topic
 
-def process_chat(text: str, history_string: str) -> str:
+def process_chat(chat_id:str, text: str, history_string: str) -> str:
     """
     Process a chat message and generate a response.
 
     Args:
+        chat_id(str): Chat id (used for caching)
         text (str): Input text message.
         history_string (str): Formatted conversation history string.
 
     Returns:
         str: The generated response.
     """
-    prompt_template = get_template("chat")
-    prompt = PromptTemplate(input_variables=["history", "human_input"], template=prompt_template)
 
-    chatgpt_chain = LLMChain(
-        llm=initialize_language_model(SELECTED_MODEL),
-        prompt=prompt,
-        verbose=False,
-        memory=ConversationBufferMemory(),
-    )
-
-    output = chatgpt_chain.predict(history=history_string, human_input=text)
-
+    chatgpt_chain = load_chat_model(chat_id)
+    output = chatgpt_chain.predict(human_input=text)
+    save_memory_to_disk(chat_id, chatgpt_chain)
     return output
 
 async def process_image(text: str, history_string: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ uvicorn==0.21.1
 librosa
 python-multipart
 pinecone-client==2.2.1
+tiktoken==0.3.3
+faiss-cpu==1.7.4


### PR DESCRIPTION
Added memory is a combination of two parts: 
First - `Faiss` based memory and second - recent K interaction memory. `Faiss` based memory retrieves top P related interaction to the current input. This kind of combination has the benefit of being able to retrieve contextual memory that is buried deep in the conversation history, but also being highly relevant to the latest interactions. Please see the updated chat chat template.

This memory can be saved to disk as pickle file and loaded whenever needed.
Also  `@functools.cache` is used now, which is new from python 3.9  (Either readme should be updated or memoization should be done manually)